### PR TITLE
Update ontolgies, classes & properties

### DIFF
--- a/example/index2.html
+++ b/example/index2.html
@@ -1,0 +1,286 @@
+<html>
+<head>
+    <title>RDF2HTML example</title>
+	<script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
+    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css" />
+    <script src="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.js"></script>
+
+    <!-- Latest compiled and minified bootstrap CSS -->
+    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
+
+    <!-- Optional bootstrap theme -->
+    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootswatch/3.1.1/flatly/bootstrap.min.css">
+	
+	<!-- Latest compiled and minified JavaScript -->
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
+
+    <link rel="stylesheet" href="example.css" type="text/css" media="screen" />
+    <script src="../build/rdf2html.js"></script>
+</head>
+<body>
+    <div class='container'>
+        <div class='row'>
+            <div class='col-xs-12'>
+                <nav class="navbar navbar-default" role="navigation">
+                    <div class="navbar-header">
+                        <a class="navbar-brand" href="#">RDF2HTML</a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+		
+		<div class="panel-group" id="accordion">
+				<div class="panel panel-default">
+					<div class="panel-heading">
+						<h4 class="panel-title" data-toggle="collapse" data-parent="#accordion" href="#collapseOntology">
+							<span class="glyphicon glyphicon-chevron-up"></span> Ontology-related Details
+						</h4>
+					</div>
+                    <div id="collapseOntology" class="panel-collapse collapse in">
+                        <div class="panel-body" data-rdftohtml-plugin='ontology'></div>
+                    </div>
+                </div>
+			</br>
+				<div class="panel panel-default">
+					<div class="panel-heading">
+						<h4 class="panel-title" data-toggle="collapse" data-parent="#accordion" href="#collapseTriples">
+						<span class="glyphicon glyphicon-chevron-up"> Triples
+						</h4>
+					</div>
+                    <div id="collapseTriples" class="panel-collapse collapse in">
+                        <div class="panel-body" data-rdftohtml-plugin='triples'></div>
+                    </div>
+                </div>
+			</br>
+				<div class="panel panel-default">
+					<div class="panel-heading">
+						<h4 class="panel-title" data-toggle="collapse" data-parent="#accordion" href="#collapseMap">
+							<span class="glyphicon glyphicon-chevron-up"> Map
+						</h4>
+					</div>
+                    <div id="collapseMap" class="panel-collapse collapse in">
+                        <div class="panel-body" data-rdftohtml-plugin='map'></div>
+                    </div>
+                </div>
+		</div>
+
+        <!--<div data-rdftohtml-plugin='paging'></div> -->
+    </div>
+
+	<script>
+		$('.collapse').on('shown.bs.collapse', function(){
+			$(this).parent().find(".glyphicon-chevron-down").removeClass("glyphicon-chevron-down").addClass("glyphicon-chevron-up");
+				}).on('hidden.bs.collapse', function(){
+					$(this).parent().find(".glyphicon-chevron-up").removeClass("glyphicon-chevron-up").addClass("glyphicon-chevron-down");
+			});
+	</script>
+	
+    <!-- You can now set the turtle over here: -->
+    <script id="turtle" type="text/turtle">
+		@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+		@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+		@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+		@prefix mfg:     <http://www.workingontologist.org/Examples/Chapter3/Product.owl#> .
+		@prefix daml:    <http://www.daml.org/2001/03/daml+oil#> .
+		@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+
+		<http://www.workingontologist.org/Examples/Chapter3/Product.owl>
+			  a       owl:Ontology ;
+			  owl:versionInfo "Created with TopBraid Spreadsheet converter"^^xsd:string .
+
+		mfg:Product
+			  a       owl:Class ;
+              owl:disjointWith mfg:Product .
+
+		mfg:Product1
+			  a       mfg:Product ;
+			  rdfs:label "Product 1"^^xsd:string ;
+			  mfg:Product_Available
+					  "23"^^xsd:string ;
+			  mfg:Product_Division
+					  "Manufacturing support"^^xsd:string ;
+			  mfg:Product_ID "1"^^xsd:string ;
+			  mfg:Product_Manufacture_Location
+					  "Sacramento"^^xsd:string ;
+			  mfg:Product_ModelNo "ZX-3"^^xsd:string ;
+			  mfg:Product_Product_Line
+					  "Papermachine"^^xsd:string ;
+			  mfg:Product_SKU "FB3524"^^xsd:string .
+
+		mfg:Product2
+			  a       mfg:Product ;
+			  rdfs:label "Product 2"^^xsd:string ;
+			  mfg:Product_Available
+					  "4"^^xsd:string ;
+			  mfg:Product_Division
+					  "Manufacturing support"^^xsd:string ;
+			  mfg:Product_ID "2"^^xsd:string ;
+			  mfg:Product_Manufacture_Location
+					  "Sacramento"^^xsd:string ;
+			  mfg:Product_ModelNo "ZX-3P"^^xsd:string ;
+			  mfg:Product_Product_Line
+					  "Paper machine"^^xsd:string ;
+			  mfg:Product_SKU "KD5243"^^xsd:string .
+
+		mfg:Product3
+			  a       mfg:Product ;
+			  rdfs:label "Product 3"^^xsd:string ;
+			  mfg:Product_Available
+					  "34"^^xsd:string ;
+			  mfg:Product_Division
+					  "Manufacturing support"^^xsd:string ;
+			  mfg:Product_ID "3"^^xsd:string ;
+			  mfg:Product_Manufacture_Location
+					  "Sacramento"^^xsd:string ;
+			  mfg:Product_ModelNo "ZX-3S"^^xsd:string ;
+			  mfg:Product_Product_Line
+					  "Paper machine"^^xsd:string ;
+			  mfg:Product_SKU "IL4028"^^xsd:string .
+
+		mfg:Product4
+			  a       mfg:Product ;
+			  rdfs:label "Product 4"^^xsd:string ;
+			  mfg:Product_Available
+					  "23"^^xsd:string ;
+			  mfg:Product_Division
+					  "Control Engineering"^^xsd:string ;
+			  mfg:Product_ID "4"^^xsd:string ;
+			  mfg:Product_Manufacture_Location
+					  "Elizabeth"^^xsd:string ;
+			  mfg:Product_ModelNo "B-1430"^^xsd:string ;
+			  mfg:Product_Product_Line
+					  "Feedback line"^^xsd:string ;
+			  mfg:Product_SKU "KS4520"^^xsd:string .
+
+		mfg:Product5
+			  a       mfg:Product ;
+			  rdfs:label "Product 5"^^xsd:string ;
+			  mfg:Product_Available
+					  "14"^^xsd:string ;
+			  mfg:Product_Division
+					  "Control Engineering"^^xsd:string ;
+			  mfg:Product_ID "5"^^xsd:string ;
+			  mfg:Product_Manufacture_Location
+					  "Elizabeth"^^xsd:string ;
+			  mfg:Product_ModelNo "B-1430X"^^xsd:string ;
+			  mfg:Product_Product_Line
+					  "Feedback line"^^xsd:string ;
+			  mfg:Product_SKU "CL5934"^^xsd:string .
+
+		mfg:Product6
+			  a       mfg:Product ;
+			  rdfs:label "Product 6"^^xsd:string ;
+			  mfg:Product_Available
+					  "0"^^xsd:string ;
+			  mfg:Product_Division
+					  "Control Engineering"^^xsd:string ;
+			  mfg:Product_ID "6"^^xsd:string ;
+			  mfg:Product_Manufacture_Location
+					  "Seoul"^^xsd:string ;
+			  mfg:Product_ModelNo "B-1431"^^xsd:string ;
+			  mfg:Product_Product_Line
+					  "Active sensor"^^xsd:string ;
+			  mfg:Product_SKU "KK3945"^^xsd:string .
+
+		mfg:Product7
+			  a       mfg:Product ;
+			  rdfs:label "Product 7"^^xsd:string ;
+			  mfg:Product_Available
+					  "100"^^xsd:string ;
+			  mfg:Product_Division
+					  "Accessories"^^xsd:string ;
+			  mfg:Product_ID "7"^^xsd:string ;
+			  mfg:Product_Manufacture_Location
+					  "Hong Kong"^^xsd:string ;
+			  mfg:Product_ModelNo "DBB-12"^^xsd:string ;
+			  mfg:Product_Product_Line
+					  "Monitor"^^xsd:string ;
+			  mfg:Product_SKU "ND5520"^^xsd:string .
+
+		mfg:Product8
+			  a       mfg:Product ;
+			  rdfs:label "Product 8"^^xsd:string ;
+			  mfg:Product_Available
+					  "HI4554"^^xsd:string ;
+			  mfg:Product_Division
+					  "Safety"^^xsd:string ;
+			  mfg:Product_ID "8"^^xsd:string ;
+			  mfg:Product_Manufacture_Location
+					  "valve"^^xsd:string ;
+			  mfg:Product_ModelNo "SP-1234"^^xsd:string ;
+			  mfg:Product_Product_Line
+					  "Safety"^^xsd:string ;
+			  mfg:Product_SKU "Cleveland"^^xsd:string .
+
+		mfg:Product9
+			  a       mfg:Product ;
+			  rdfs:label "Product 9"^^xsd:string ;
+			  mfg:Product_Available
+					  "OP5333"^^xsd:string ;
+			  mfg:Product_Division
+					  "Safety"^^xsd:string ;
+			  mfg:Product_ID "9"^^xsd:string ;
+			  mfg:Product_Manufacture_Location
+					  "valve"^^xsd:string ;
+			  mfg:Product_ModelNo "SPX-1234"^^xsd:string ;
+			  mfg:Product_Product_Line
+					  "Safety"^^xsd:string ;
+			  mfg:Product_SKU "Cleveland"^^xsd:string .
+
+		mfg:Product_Available
+			  a       owl:DatatypeProperty ;
+			  rdfs:domain mfg:Product ;
+			  rdfs:label "Available"^^xsd:string ;
+			  rdfs:range xsd:string .
+
+		mfg:Product_Division
+			  a       owl:DatatypeProperty ;
+			  rdfs:domain mfg:Product ;
+			  rdfs:label "Division"^^xsd:string ;
+			  rdfs:range xsd:string .
+
+		mfg:Product_ID
+			  a       owl:DatatypeProperty ;
+			  rdfs:domain mfg:Product ;
+			  rdfs:label "ID"^^xsd:string ;
+			  rdfs:range xsd:string .
+
+		mfg:Product_Manufacture_Location
+			  a       owl:DatatypeProperty ;
+			  rdfs:domain mfg:Product ;
+			  rdfs:label "Manufacture Location"^^xsd:string ;
+			  rdfs:range xsd:string .
+
+		mfg:Product_ModelNo
+			  a       owl:DatatypeProperty ;
+			  rdfs:domain mfg:Product ;
+			  rdfs:label "ModelNo"^^xsd:string ;
+			  rdfs:range xsd:string .
+
+		mfg:Product_Product_Line
+			  a       owl:DatatypeProperty ;
+			  rdfs:domain mfg:Product ;
+			  rdfs:label "Product Line"^^xsd:string ;
+			  owl:inverseOf mfg:Product_ModelNo ;
+			  rdfs:range xsd:string .
+
+		mfg:Product_SKU
+			  a       owl:DatatypeProperty ;
+			  rdfs:domain mfg:Product ;
+			  rdfs:label "SKU"^^xsd:string ;
+			  rdfs:range xsd:string .
+    </script>
+
+    <!-- Run RDF2HTML -->
+    <script type="text/javascript">
+        var triples = document.getElementById("turtle").innerHTML;
+        var config = {
+            // Plugins to be called, add your own plugin to the plugin definition in rdf2hml.js and compile
+            plugins: ['triples', 'map', 'ontology', 'paging'],
+            // Output information to the console, errors are always logged to the console
+            verbose: true
+        };
+        rdf2html(triples, config);
+    </script>
+</body>
+</html>

--- a/plugins/ontology/ontology.js
+++ b/plugins/ontology/ontology.js
@@ -7,32 +7,87 @@
 */
 
 var $ = require('jquery');
+                     
+//create table based on http://www.w3.org/TR/2004/REC-owl-semantics-20040210/#indexs
+var propertyProperties = [["Domain", rdfsPrefix + "domain"], ["Range", rdfsPrefix + "range"], ["Inverse of", owlPrefix + "inverseOf"]];
+
+var ontologyProperties = [["Backward compatible with", owlPrefix + "backwardCompatibleWith"], ["Imports", owlPrefix + "imports"], ["Incompatible with", owlPrefix + "incompatibleWith"], ["Prior version", owlPrefix + "priorVersion"], ["Version IRI", owlPrefix + "versionIRI"], ["Version info", owlPrefix + "versionInfo"]];
+
+var classesProperties = [["Complement of", owlPrefix + "complementOf"], ["Disjoint union of",owlPrefix + "disjointUnionOf"], ["Disjoint with", owlPrefix + "disjointWith"], ["Has key", owlPrefix + "hasKey"]];
 
 // Main closure
 module.exports =  function(db, container, prefixes) {
+    addOntologies(db, container);
     addClasses(db, container);
     addProperties(db, container);
     addMisc(db, container);
 };
 
-var addClasses = function (db, container) {
+// Add 2 column table row
+function createTableRow(col1, col2) {
+    var row = $('<tr></tr>');
+    row.append('<td>' + col1 + '</td>');
+    row.append('<td>' + col2 + '</td>');
+    return row;
+}
 
-    var triples = db.find(null, "http://www.w3.org/2000/01/rdf-schema#subClassOf", null);
 
+function addEntity(db, container, entity, owlEntity, properties) {
+    var triples = db.find(null, null, owlEntity);
+    var rdf2htmlID = "rdf2html-" + entity.toLowerCase();
+    
     if (triples.length > 0) {
-        container.append('<h4>Classes</h4><div id="rdf2html-classes"></div>');
+		container.append('<div class="panel-group" id="accordion' + entity + '"><div class="panel panel-default"><div class="panel-heading"><h4 class="panel-title" data-toggle="collapse" data-parent="#accordion' + entity + '" href="#collapse' + entity + '"><span class="glyphicon glyphicon-chevron-up"></span> ' + entity + '</h4></div><div id="collapse' + entity + '" class="panel-collapse collapse in"><div class="panel-body" id="' + rdf2htmlID + '"></div></div>');
 
         triples.forEach(function (data) {
-            $("#rdf2html-classes").append("<h5>" + linkify(data["subject"]) + "</h5>");
-            $("#rdf2html-classes").append("<p><label>SubClassOf:</label> " + linkify(data["object"]) + "</p>");
+            $("#" + rdf2htmlID).append("<h4 class='subject' id='" + removePrefix(data["subject"], knownPrefixes) + "'><a href='" + data["subject"] + "'>" + searchForLabel(data["subject"], db) + "</a></h4>");
+            
+            rows = createPropertyRows(data, db, properties);
+			
+			if (rows.length > 0) {
+				var table = $('<table class="triples table table-hover"></table>');
+				table.append(rows);
+				$("#" + rdf2htmlID).append(table);
+			}
         });
     }
+}
 
-};
+var addClasses = function (db, container) {
+    addEntity(db, container, "Classes", "http://www.w3.org/2002/07/owl#Class", classesProperties);
+}
 
 var addProperties = function (db, container) {
-    // TODO
-};
+    addEntity(db, container, "Properties", "http://www.w3.org/2002/07/owl#DatatypeProperty", propertyProperties);
+}
+
+
+var addOntologies = function (db, container) {
+    addEntity(db, container, "Ontology", owlPrefix + "Ontology", ontologyProperties);   
+}
+
+//creates the different rows for the properties of the Property elements of the ontology.
+function createPropertyRows(data, db, properties) {
+	var rows = [];
+	
+	for (var index = 0; index < properties.length; index++) {
+		var property = properties[index];
+		var results = db.find(data["subject"], property[1], null);
+			
+		if (results.length > 0) {
+			results.forEach(function (result) {
+                if(isLiteral(result.object)) {
+                    rows.push(createTableRow("<a href='" + property[1] + "'>" + property[0] + "</a>", getLiteralValue(result.object)));
+                } else {
+				rows.push(createTableRow("<a href='" + property[1] + "'>" + property[0] + "</a>", "<a href='#" + removePrefix(result["object"], knownPrefixes) + "'>" + searchForLabel(result["object"], db) + "</a>"));
+                }
+			});
+		}
+	}
+	
+	return rows;
+}
+
 
 var addMisc = function (db, container) {
     // TODO

--- a/plugins/triples/triples.js
+++ b/plugins/triples/triples.js
@@ -33,8 +33,6 @@ module.exports =  function (db, container, prefixes) {
 		return !containsTriple(item, allClasses) && !containsTriple(item, allProperties) && !containsTriple(item, allOntologies);
 	});
     
-    alert(allTriples.length + ", " + triples.length);
-
     // Add 2 column table row
     var createTableRow = function (col1, col2) {
         var row = $('<tr></tr>');

--- a/plugins/triples/triples.js
+++ b/plugins/triples/triples.js
@@ -9,8 +9,31 @@ var $ = require('jquery');
 
 module.exports =  function (db, container, prefixes) {
 
+	function compareTriples(triple1, triple2) {
+		return triple1.subject === triple2.subject;
+	}
+	
+	function containsTriple(triple, store) {
+		index = 0;
+		
+		while (index < store.length && !compareTriples(triple, store[index])) {
+			index ++;
+		}
+		
+		return index < store.length;
+	}
+
     // Get all triples
-    var triples = db.find(null, null, null);
+    var allTriples = db.find(null, null, null);
+	var allClasses = db.find(null, null, "http://www.w3.org/2002/07/owl#Class");
+    var allOntologies = db.find(null, null, "http://www.w3.org/2002/07/owl#Ontology");
+	var allProperties = db.find(null, null, "http://www.w3.org/2002/07/owl#DatatypeProperty");
+	
+	var triples =  allTriples.filter(function(item) {
+		return !containsTriple(item, allClasses) && !containsTriple(item, allProperties) && !containsTriple(item, allOntologies);
+	});
+    
+    alert(allTriples.length + ", " + triples.length);
 
     // Add 2 column table row
     var createTableRow = function (col1, col2) {
@@ -66,7 +89,7 @@ module.exports =  function (db, container, prefixes) {
                 }
 
                 // Add row
-                rows.push(createTableRow(predicate, object));
+                rows.push(createTableRow("<a href='" + data.predicate + "'>" + searchForLabel(data.predicate, db) + "</a>", object));
             });
         }
 

--- a/utilities.js
+++ b/utilities.js
@@ -2,6 +2,39 @@
  * Global utility functions
  */
 
+global.owlPrefix = "http://www.w3.org/2002/07/owl#";
+global.rdfsPrefix = "http://www.w3.org/2000/01/rdf-schema#";
+
+//this information should be acquired from the n3
+global.knownPrefixes = [owlPrefix, rdfsPrefix, "http://www.w3.org/2001/XMLSchema#", "http://www.w3.org/1999/02/22-rdf-syntax-ns#", "http://www.workingontologist.org/Examples/Chapter3/Product.owl#"];
+
+//Remove prefix from URI
+//@prefixes is an array
+global.removePrefix = function (uri, prefixes) {
+    var index = 0; 
+    
+    while(index < prefixes.length && uri.indexOf(prefixes[index]) != 0) {
+          index ++;
+    }
+          
+    if (index < prefixes.length) {
+        return uri.replace(prefixes[index], "");
+    } else {
+        return uri;
+    }
+}
+
+//search if an element has a label, if this is not the case the name without the prefix is returned.
+global.searchForLabel = function (data, db) {
+        var results = db.find(data, "http://www.w3.org/2000/01/rdf-schema#label", null);
+
+        if (results.length > 0) {
+            return getLiteralValue(results[0]["object"]);
+        }
+
+        return removePrefix(data, knownPrefixes);
+}
+
 // Function to turn links in to link
 global.linkify = function(text, prefixes) {
     if (text) {


### PR DESCRIPTION
index2.html added (tested example)
triples.js only produces the triples that are not used by ontology.js

UI bug regarding the arrows when collapsing panels

The information provided for the ontology elements is hard coded (using an array), just so that we control a lil what is being displayed, however, you can show everything related to a class of property of course if needed.